### PR TITLE
Fix variable names for 'refreshCommands'

### DIFF
--- a/utilities/refreshCommands.js
+++ b/utilities/refreshCommands.js
@@ -15,7 +15,7 @@ for (const file of commandFiles) {
 }
 
 // Construct and prepare an instance of the REST module
-const rest = new REST({ version: '10' }).setToken(process.env.token);
+const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);
 
 // and deploy your commands!
 (async () => {
@@ -24,7 +24,7 @@ const rest = new REST({ version: '10' }).setToken(process.env.token);
 
 		// The put method is used to fully refresh all commands in the guild with the current set
 		const data = await rest.put(
-			Routes.applicationGuildCommands(process.env.client_id, process.env.guild_id),
+			Routes.applicationGuildCommands(process.env.CLIENT_ID, process.env.GUILD_ID),
 			{ body: commands },
 		);
 


### PR DESCRIPTION
Variable names in 'refreshCommands' need to be fixed to capital names since the file refuses to run due to missing env vars.